### PR TITLE
Update buddydrive-item-ajax.php

### DIFF
--- a/includes/buddydrive-item-ajax.php
+++ b/includes/buddydrive-item-ajax.php
@@ -412,7 +412,7 @@ function buddydrive_delete_items() {
 
 	$items = substr( $items, 0, strlen( $items ) - 1 );
 
-	$items = explode( ',', $items );
+	$items = array_filter(explode( ',', $items ));
 
 	$items_nbre = buddydrive_delete_item( array( 'ids' => $items ) );
 


### PR DESCRIPTION
Hello Imath, i found that making an ajax call to "buddydrive_deleteitems" action with the right nonce and passing "items=0," as a parameter it accept the "0" as value so deletes almost all posts in my database with all related buddydrive files and not only what is supposed to be deleted(in the case of a "0", nothing). That's the reason of my proposal. Hope this can help.