### PR TITLE
Fix:  Allow BuddyDrive to send files larger than the WP Memory Limit

### DIFF
--- a/includes/buddydrive-item-actions.php
+++ b/includes/buddydrive-item-actions.php
@@ -274,6 +274,12 @@ function buddydrive_file_downloader() {
 			header( 'Content-Length: ' . filesize( $buddydrive_file_path ) );
 			header( 'Content-Disposition: attachment; filename='.$buddydrive_file_name );
 			header( 'Content-Type: ' .$buddydrive_file_mime );
+			// Files larger than the WordPress memory limit will cause out of memory errors
+			// if output buffering is on.  Check to see if the ob level is > 0 and if it is
+			// we send the buffer and then end ob.  We do not restart ob, since we die() after.
+			while (ob_get_level() > 0) {
+				ob_end_flush();
+			}
 			readfile( $buddydrive_file_path );
 			die();
 		}


### PR DESCRIPTION
If your WP memory limit is 256M as an example, and PHP's output buffering is being used anywhere on the site, and you are downloading a file > 256M (or whatever the WP memory limit is), output buffering must be turned off before PHP's readfile occurs, or you will get an out of memory error in your error_log and the file will not download.  Now, files can be of any size regardless of ob's level, and regardless of WP's memory limit.

Cheers
Ben, co-developer at WCVendors, another WordPress plugin